### PR TITLE
Fix epoch timestamp for collectionTime

### DIFF
--- a/bluefloodserver/blueflood.py
+++ b/bluefloodserver/blueflood.py
@@ -56,7 +56,7 @@ class BluefloodEndpoint():
 
 
         data = [{
-            "collectionTime": t,
+            "collectionTime": t*1000,
             "ttlInSeconds": ttl,
             "metricValue": v,
             "metricName": metric_name


### PR DESCRIPTION
Blueflood takes timestamps in milliseconds, instead of seconds. This is like a quick fix. Ideally, I would like to have more granular timestamps in ms generated while collection, can we do that? I do not have insight into the codebase to have an accurate say...
